### PR TITLE
try-catch on json parsing only

### DIFF
--- a/lib/master/WorkerControl.js
+++ b/lib/master/WorkerControl.js
@@ -204,31 +204,31 @@ Worker.prototype.work = function(data, givenJobCallback) {
         res.on('end', function () {
             if (that.waitingTimeout) {
                 clearTimeout(that.waitingTimeout); // clear the "worker did not answer" timeout
+                log(that.id, 'received result: ' + body);
                 try {
-                    log(that.id, 'received result: ' + body);
                     // parse results and pass them to our callback
                     var result = JSON.parse(body);
-                    if (result.status === 'success') {
-                        jobCallback(null, result.data);
-                    } else if (result.status === 'fail') {
-                        jobCallback(createError(that.id, result.errMessage), result.data);
-                    } else {
-                        jobCallback(createError(that.id, 'Communication error between Master and Worker'));
-                        result.closing = true;
-                        that.createProcess();
-                    }
-                    that.currentJob = null;
-
-                    // check if phatomjs instance will close down
-                    // if the worker signals he is closing, then we just wait for its closing
-                    // otherwise we get a job for the worker
-                    if (!result.closing) {
-                        that.readyForWork();
-                    }
                 } catch (jsonParseError) {
                     // if that happens, we are in trouble
                     jobCallback(createError(that.id, 'JSON.parse error (content: ' + body + ')'));
                     that.createProcess();
+                }
+                if (result.status === 'success') {
+                    jobCallback(null, result.data);
+                } else if (result.status === 'fail') {
+                    jobCallback(createError(that.id, result.errMessage), result.data);
+                } else {
+                    jobCallback(createError(that.id, 'Communication error between Master and Worker'));
+                    result.closing = true;
+                    that.createProcess();
+                }
+                that.currentJob = null;
+
+                // check if phatomjs instance will close down
+                // if the worker signals he is closing, then we just wait for its closing
+                // otherwise we get a job for the worker
+                if (!result.closing) {
+                    that.readyForWork();
                 }
             }
         });


### PR DESCRIPTION
this is to avoid the misleading errors. For example, in the past,
phantomjs failed but the reported error is jsonParserError.